### PR TITLE
Fixing maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,26 @@
             <artifactId>bluetooth-manager-dbus</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.hypfvieh</groupId>
+            <artifactId>dbus-java</artifactId>
+            <version>2.7.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.hypfvieh</groupId>
+            <artifactId>java-utils</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.hypfvieh</groupId>
+            <artifactId>libmatthew</artifactId>
+            <version>0.8.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This is just to fix maven dependencies and prepare the binding/transport to be available for public.

Now when you run `mvn clean install` a proper OSGi bundle with all necessary dependencies gets built so it can be used directly.